### PR TITLE
Plane: Add tiltrotor roll differential thrust

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -337,7 +337,7 @@ void Tailsitter::output(void)
 
         if (!quadplane.assisted_flight) {
             // set AP_MotorsMatrix throttles for forward flight
-            motors->output_motor_mask(throttle, motor_mask, plane.rudder_dt);
+            motors->output_motor_mask(throttle, motor_mask, plane.rudder_dt, 0);
 
             // in forward flight: set motor tilt servos and throttles using FW controller
             if (vectored_forward_gain > 0) {

--- a/ArduPlane/tiltrotor.h
+++ b/ArduPlane/tiltrotor.h
@@ -80,6 +80,7 @@ public:
     AP_Float fixed_gain;
     AP_Float flap_angle_deg;
     AP_Int16 max_rate_down_final_dps;
+    AP_Float roll_diff;
 
     float current_tilt;
     float current_throttle;

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -71,7 +71,7 @@ public:
     // return the pitch factor of any motor
     float               get_pitch_factor(uint8_t i) override { return _pitch_factor[i]; }
 
-    // return the yaw factor of any motor, this is used for tilt rotors and tail sittersAdd commentMore actions
+    // return the yaw factor of any motor, this is used for tilt rotors and tail sitters
     // using copter motors for forward flight
     float               get_yaw_factor(uint8_t i) override { return _yaw_factor[i]; }
     

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -71,6 +71,10 @@ public:
     // return the pitch factor of any motor
     float               get_pitch_factor(uint8_t i) override { return _pitch_factor[i]; }
 
+    // return the yaw factor of any motor, this is used for tilt rotors and tail sittersAdd commentMore actions
+    // using copter motors for forward flight
+    float               get_yaw_factor(uint8_t i) override { return _yaw_factor[i]; }
+    
     // disable the use of motor torque to control yaw. Used when an external mechanism such
     // as vectoring is used for yaw control
     void                disable_yaw_torque(void) override;

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -733,11 +733,11 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint16_t mask, float 
                  apples to either tilted motors or tailsitters
                  */
                 float diff_thrust = get_roll_factor(i) * rudder_dt * 0.5f;
-                /*Add commentMore actions
+                /*
                  apply aileron mixing differential thrust
                  copter frame yaw is plane frame roll as this only
                  apples to either tilted motors or tailsitters
-                */Add commentMore actions
+                 */
                 diff_thrust += get_yaw_factor(i) * aileron_dt * 0.5f;
                 set_actuator_with_slew(_actuator[i], thrust + diff_thrust);
                 int16_t pwm_output = pwm_min + pwm_range * _actuator[i];

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -719,7 +719,7 @@ void AP_MotorsMulticopter::set_throttle_passthrough_for_esc_calibration(float th
 // output a thrust to all motors that match a given motor mask. This
 // is used to control tiltrotor motors in forward flight. Thrust is in
 // the range 0 to 1
-void AP_MotorsMulticopter::output_motor_mask(float thrust, uint16_t mask, float rudder_dt)
+void AP_MotorsMulticopter::output_motor_mask(float thrust, uint16_t mask, float rudder_dt, float aileron_dt)
 {
     const int16_t pwm_min = get_pwm_output_min();
     const int16_t pwm_range = get_pwm_output_max() - pwm_min;
@@ -733,6 +733,12 @@ void AP_MotorsMulticopter::output_motor_mask(float thrust, uint16_t mask, float 
                  apples to either tilted motors or tailsitters
                  */
                 float diff_thrust = get_roll_factor(i) * rudder_dt * 0.5f;
+                /*Add commentMore actions
+                 apply aileron mixing differential thrust
+                 copter frame yaw is plane frame roll as this only
+                 apples to either tilted motors or tailsitters
+                */Add commentMore actions
+                diff_thrust += get_yaw_factor(i) * aileron_dt * 0.5f;
                 set_actuator_with_slew(_actuator[i], thrust + diff_thrust);
                 int16_t pwm_output = pwm_min + pwm_range * _actuator[i];
                 rc_write(i, pwm_output);

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -60,7 +60,7 @@ public:
     // output a thrust to all motors that match a given motor
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
-    virtual void        output_motor_mask(float thrust, uint16_t mask, float rudder_dt);
+    virtual void        output_motor_mask(float thrust, uint16_t mask, float rudder_dt, float aileron_dt);
 
     // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -333,10 +333,10 @@ void AP_MotorsTri::thrust_compensation(void)
 /*
   override tricopter tail servo output in output_motor_mask
  */
-void AP_MotorsTri::output_motor_mask(float thrust, uint16_t mask, float rudder_dt)
+void AP_MotorsTri::output_motor_mask(float thrust, uint16_t mask, float rudder_dt, float aileron_dt)
 {
     // normal multicopter output
-    AP_MotorsMulticopter::output_motor_mask(thrust, mask, rudder_dt);
+    AP_MotorsMulticopter::output_motor_mask(thrust, mask, rudder_dt, aileron_dt);
 
     // and override yaw servo
     rc_write_angle(AP_MOTORS_CH_TRI_YAW, 0);

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -42,7 +42,7 @@ public:
     // mask. This is used to control tiltrotor motors in forward
     // flight. Thrust is in the range 0 to 1
     // rudder_dt applys diffential thrust for yaw in the range 0 to 1
-    void                output_motor_mask(float thrust, uint16_t mask, float rudder_dt) override;
+    void                output_motor_mask(float thrust, uint16_t mask, float rudder_dt, float aileron_dt) override;
 
     // return the roll factor of any motor, this is used for tilt rotors and tail sitters
     // using copter motors for forward flight

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -251,7 +251,7 @@ public:
     // return the pitch factor of any motor
     virtual float       get_pitch_factor(uint8_t i) { return 0.0f; }
 
-    // return the yaw factor of any motor, this is used for tilt rotors and tail sittersAdd commentMore actions
+    // return the yaw factor of any motor, this is used for tilt rotors and tail sitters
     // using copter motors for forward flight
     virtual float       get_yaw_factor(uint8_t i) { return 0.0f; }
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -251,6 +251,10 @@ public:
     // return the pitch factor of any motor
     virtual float       get_pitch_factor(uint8_t i) { return 0.0f; }
 
+    // return the yaw factor of any motor, this is used for tilt rotors and tail sittersAdd commentMore actions
+    // using copter motors for forward flight
+    virtual float       get_yaw_factor(uint8_t i) { return 0.0f; }
+
     // return whether a motor is enabled or not
     virtual bool        is_motor_enabled(uint8_t i) { return false; }
 


### PR DESCRIPTION
Adds a new `TILT_ROLL_DIFF` parameter for tiltrotors with coaxial pairs on the tilt axle.

This prevents roll imbalance when front motors generate more back-torque than rear motors, which causes ailerons to fight against them. The parameter sets the thrust difference as a percentage at full scale.

**Changes:**
- Added `TILT_ROLL_DIFF` parameter to tiltrotor configuration
- Modified `output_motor_mask()` to accept aileron differential thrust
- Updated motor output functions to apply differential thrust based on throttle and roll diff setting

Helps with roll control on tiltrotor aircraft where motor torque differences cause unwanted roll moments.